### PR TITLE
added user cluster roles DK-1854

### DIFF
--- a/chart/k8svault-controller/templates/clusterrole-edit.yaml
+++ b/chart/k8svault-controller/templates/clusterrole-edit.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.clusterRBAC.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "k8svault-controller.fullname" . }}-edit
+  labels:
+    app.kubernetes.io/name: {{ include "k8svault-controller.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "k8svault-controller.chart" . }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+rules:
+- apiGroups:
+  - "vault.infra.doodle.com"
+  resources:
+  - vaultbindings
+  - vaultmirrors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - "vault.infra.doodle.com"
+  resources:
+  - vaultbindings/status
+  - vaultmirrors/status
+  verbs:
+  - get
+{{- end }}

--- a/chart/k8svault-controller/templates/clusterrole-view.yaml
+++ b/chart/k8svault-controller/templates/clusterrole-view.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.clusterRBAC.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "k8svault-controller.fullname" . }}-view
+  labels:
+    app.kubernetes.io/name: {{ include "k8svault-controller.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "k8svault-controller.chart" . }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+rules:
+- apiGroups:
+  - "vault.infra.doodle.com"
+  resources:
+  - vaultbindings
+  - vaultmirrors
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "vault.infra.doodle.com"
+  resources:
+  - vaultbindings/status
+  - vaultmirrors/status
+  verbs:
+  - get
+{{- end }}


### PR DESCRIPTION
Adds two cluster roles, one for read and one for edit/admin access.
Both come with the default aggregate labels to include them in the according roles.